### PR TITLE
Small fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1
 
-ENV FGALLERY_VERSION 1.8.1
+ENV FGALLERY_VERSION 1.8.2
 
 RUN export DEBIAN_FRONTEND noninteractive \
   && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,24 @@ ENV FGALLERY_VERSION 1.8.2
 
 RUN export DEBIAN_FRONTEND noninteractive \
   && apt-get update \
-  && apt-get install -y --no-install-recommends curl imagemagick exiftran zip liblcms2-utils libimage-exiftool-perl libjson-perl libjson-xs-perl jpegoptim pngcrush p7zip \
+  && apt-get install -y --no-install-recommends \
+       curl \
+       imagemagick \
+       exiftran \
+       zip \
+       liblcms2-utils \
+       libimage-exiftool-perl \
+       libjson-perl \
+       libjson-xs-perl \
+       jpegoptim \
+       pngcrush \
+       p7zip \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # extract in /src, mv to /app
 RUN mkdir /fgallery \
-  && curl -sL "https://github.com/wavexx/fgallery/archive/fgallery-${FGALLERY_VERSION}.tar.gz" | tar xz -C /fgallery \
+  && curl -sL "https://github.com/wavexx/fgallery/archive/fgallery-${FGALLERY_VERSION}.tar.gz" \
+     | tar xz -C /fgallery \
   && ln -nsf "/fgallery/fgallery-fgallery-${FGALLERY_VERSION}/"* /fgallery
 
 COPY docker-entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV FGALLERY_VERSION 1.8.2
 RUN export DEBIAN_FRONTEND noninteractive \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
+       ca-certificates \
        curl \
        imagemagick \
        exiftran \

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-Simple Image Gallary
+Simple Image Gallery
 ====================
 
 A simple way photo gallery container using
-[FGallary](https://github.com/wavexx/fgallery).
+[fgallery](https://github.com/wavexx/fgallery).
 
 Usage
 -----
 
-At its core, this uses the [NGinX container](https://hub.docker.com/\_/nginx/).
+At its core, this uses the [nginx container](https://hub.docker.com/\_/nginx/).
 
 Images to put in the gallery should be in the `/images` directory.
 


### PR DESCRIPTION
The image doesn't build in its current state because `curl` can't find the root certificates, 4bb52a2 fixes that.
 